### PR TITLE
group map transactions

### DIFF
--- a/src/containers/Expenses/hooks/useExpenses.jsx
+++ b/src/containers/Expenses/hooks/useExpenses.jsx
@@ -11,6 +11,11 @@ function useExpenses() {
     setExpenses(response);
   };
 
+  const getGroupedExpenses = async (month) => {
+    const response = await get(`expenses/map_view?from=${month}`);
+    setExpenses(response);
+  };
+
   const createExpense = async (values) => {
     try {
       setLoading(true);
@@ -43,6 +48,7 @@ function useExpenses() {
     expenses,
     actions: {
       getExpenses,
+      getGroupedExpenses,
       updateExpenses,
       createExpense,
     },

--- a/src/containers/Map/index.jsx
+++ b/src/containers/Map/index.jsx
@@ -31,7 +31,7 @@ function MapViewContainer() {
 
   const markers = expensesWithLocation.map((expense) => ({
     position: [expense.latitude, expense.longitude],
-    content: `${expense.category_name}: ${expense.amount}`,
+    content: `${expense.category_names}: ${expense.amount_spent}`,
   }));
 
   const customIcon = L.icon({
@@ -51,7 +51,7 @@ function MapViewContainer() {
 
   useEffect(() => {
     if (selectedMonth) {
-      actions.getExpenses(selectedMonth);
+      actions.getGroupedExpenses(selectedMonth);
     }
   }, [selectedMonth]);
 


### PR DESCRIPTION
# New
- Group transactions within 200m (show just one pin)
- Marker will show all categories and total amount spent